### PR TITLE
Let user choose mainnet/testnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Vscode
 .vscode
+.idea
 
 # MacOS
 .DS_Store

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -33,15 +33,15 @@ terra.api.Client.URL = "https://my.lcd.server"
 
 Client:
 ```python
-Client()
+Client(api_network=ApiNetwork.MAINNET)
 
-Client.get(
+Client().get(
     path: str,
     params: Optional[Dict[str, str]] = None,
     timeout: Optional[int] = 5,
 ) -> dict
 
-Client.post(
+Client().post(
     path: str,
     json: Optional[Dict[str, str]],
     params: Optional[Dict[str, str]] = None,

--- a/terra/account.py
+++ b/terra/account.py
@@ -4,7 +4,7 @@ from mnemonic import Mnemonic
 import bech32
 import bip32utils
 
-from terra import api
+from terra.api.client import Client
 
 
 class Account:
@@ -83,13 +83,12 @@ class Account:
 
     def _get_sequence(self) -> str:
         """Get sequence from api."""
-        return api.auth.accounts.by_address.get(self.account_address)[
-            "result"
-        ]["value"]["sequence"]
+        return Client().get_account_by_address(
+            self.account_address)["result"]["value"]["sequence"]
 
     def _get_account_number(self) -> str:
         """Get account number from api."""
-        return api.auth.accounts.by_address.get(self.account_address)[
+        return Client().get_account_by_address(self.account_address)[
             "result"
         ]["value"]["account_number"]
 

--- a/terra/account.py
+++ b/terra/account.py
@@ -83,14 +83,15 @@ class Account:
 
     def _get_sequence(self) -> str:
         """Get sequence from api."""
-        return Client().get_account_by_address(
-            self.account_address)["result"]["value"]["sequence"]
+        return Client().get_account_by_address(self.account_address)["result"][
+            "value"
+        ]["sequence"]
 
     def _get_account_number(self) -> str:
         """Get account number from api."""
-        return Client().get_account_by_address(self.account_address)[
-            "result"
-        ]["value"]["account_number"]
+        return Client().get_account_by_address(self.account_address)["result"][
+            "value"
+        ]["account_number"]
 
     def _derive_root(self, seed: str) -> bip32utils.BIP32Key:
         """Derive a root bip32 key object from seed."""

--- a/terra/api/__init__.py
+++ b/terra/api/__init__.py
@@ -1,7 +1,7 @@
-from terra.api import auth
-from terra.api import bank
-from terra.api import oracle
-from terra.api import tendermint
-from terra.api import transactions
+from enum import Enum
 
-__all__ = ["auth", "bank", "oracle", "tendermint", "transactions"]
+
+class ApiNetwork(Enum):
+    MAINNET = "https://lcd.terra.dev"
+    TESTNET__VODKA = "https://vodka-lcd.terra.dev"
+    TESTNET__SOJU = "https://soju-lcd.terra.dev"

--- a/terra/api/auth/__init__.py
+++ b/terra/api/auth/__init__.py
@@ -1,3 +1,0 @@
-from terra.api.auth import accounts
-
-__all__ = ["accounts"]

--- a/terra/api/auth/accounts/__init__.py
+++ b/terra/api/auth/accounts/__init__.py
@@ -1,3 +1,0 @@
-from terra.api.auth.accounts import by_address
-
-__all__ = ["by_address"]

--- a/terra/api/auth/accounts/by_address.py
+++ b/terra/api/auth/accounts/by_address.py
@@ -1,5 +1,0 @@
-from terra.api.client import Client
-
-
-def get(address: str) -> dict:
-    return Client.get(f"/auth/accounts/{address}")

--- a/terra/api/bank/__init__.py
+++ b/terra/api/bank/__init__.py
@@ -1,3 +1,0 @@
-from terra.api.bank import balances
-
-__all__ = ["balances"]

--- a/terra/api/bank/balances/__init__.py
+++ b/terra/api/bank/balances/__init__.py
@@ -1,3 +1,0 @@
-from terra.api.bank.balances import by_address
-
-__all__ = ["by_address"]

--- a/terra/api/bank/balances/by_address.py
+++ b/terra/api/bank/balances/by_address.py
@@ -1,5 +1,0 @@
-from terra.api.client import Client
-
-
-def get(address: str) -> dict:
-    return Client.get(f"/bank/balances/{address}")

--- a/terra/api/client.py
+++ b/terra/api/client.py
@@ -4,6 +4,7 @@ import logging
 
 import requests
 
+from terra.api import network
 from terra.exceptions import ApiError
 
 _log = logging.getLogger(__name__)
@@ -11,11 +12,8 @@ _log = logging.getLogger(__name__)
 
 class Client:
 
-    def __init__(self, testnet=False):
-        if testnet:
-            self.URL = "https://vodka-lcd.terra.dev"
-        else:
-            self.URL = "https://lcd.terra.dev"
+    def __init__(self, chain_url=network.MAINNET):
+        self.URL = chain_url
 
     @staticmethod
     def get(

--- a/terra/api/client.py
+++ b/terra/api/client.py
@@ -10,7 +10,12 @@ _log = logging.getLogger(__name__)
 
 
 class Client:
-    URL = "https://lcd.terra.dev"
+
+    def __init__(self, testnet=False):
+        if testnet:
+            self.URL = "https://vodka-lcd.terra.dev"
+        else:
+            self.URL = "https://lcd.terra.dev"
 
     @staticmethod
     def get(

--- a/terra/api/client.py
+++ b/terra/api/client.py
@@ -11,6 +11,8 @@ _log = logging.getLogger(__name__)
 
 
 class Client:
+    URL = network.MAINNET
+
     def __init__(self, chain_url=network.MAINNET):
         self.URL = chain_url
 

--- a/terra/api/client.py
+++ b/terra/api/client.py
@@ -11,7 +11,6 @@ _log = logging.getLogger(__name__)
 
 
 class Client:
-
     def __init__(self, chain_url=network.MAINNET):
         self.URL = chain_url
 

--- a/terra/api/network/__init__.py
+++ b/terra/api/network/__init__.py
@@ -1,3 +1,0 @@
-MAINNET = "https://lcd.terra.dev"
-TESTNET__VODKA = "https://vodka-lcd.terra.dev"
-TESTNET__SOJU = "https://soju-lcd.terra.dev"

--- a/terra/api/network/__init__.py
+++ b/terra/api/network/__init__.py
@@ -1,0 +1,3 @@
+MAINNET = "https://lcd.terra.dev"
+TESTNET__VODKA = "https://vodka-lcd.terra.dev"
+TESTNET__SOJU = "https://soju-lcd.terra.dev"

--- a/terra/api/oracle/__init__.py
+++ b/terra/api/oracle/__init__.py
@@ -1,3 +1,0 @@
-from terra.api.oracle import denoms
-
-__all__ = ["denoms"]

--- a/terra/api/oracle/denoms/__init__.py
+++ b/terra/api/oracle/denoms/__init__.py
@@ -1,3 +1,0 @@
-from terra.api.oracle.denoms import actives
-
-__all__ = ["actives"]

--- a/terra/api/oracle/denoms/actives.py
+++ b/terra/api/oracle/denoms/actives.py
@@ -1,5 +1,0 @@
-from terra.api.client import Client
-
-
-def get() -> dict:
-    return Client.get("/oracle/denoms/actives")

--- a/terra/api/tendermint/__init__.py
+++ b/terra/api/tendermint/__init__.py
@@ -1,4 +1,0 @@
-from terra.api.tendermint import blocks
-from terra.api.tendermint import node_info
-
-__all__ = ["blocks", "node_info"]

--- a/terra/api/tendermint/blocks/__init__.py
+++ b/terra/api/tendermint/blocks/__init__.py
@@ -1,3 +1,0 @@
-from terra.api.tendermint.blocks import latest
-
-__all__ = ["latest"]

--- a/terra/api/tendermint/blocks/latest.py
+++ b/terra/api/tendermint/blocks/latest.py
@@ -1,5 +1,0 @@
-from terra.api.client import Client
-
-
-def get() -> dict:
-    return Client.get("/blocks/latest")

--- a/terra/api/tendermint/node_info.py
+++ b/terra/api/tendermint/node_info.py
@@ -1,5 +1,0 @@
-from terra.api.client import Client
-
-
-def get() -> dict:
-    return Client.get("/node_info")

--- a/terra/api/transactions/__init__.py
+++ b/terra/api/transactions/__init__.py
@@ -1,3 +1,0 @@
-from terra.api.transactions import txs
-
-__all__ = ["txs"]

--- a/terra/api/transactions/txs.py
+++ b/terra/api/transactions/txs.py
@@ -1,8 +1,0 @@
-import json
-
-from terra.api.client import Client
-
-
-def post(tx_dump: str) -> dict:
-    """Broadcast the tx json dump."""
-    return Client.post("/txs", json.loads(tx_dump))

--- a/terra/msg/tx.py
+++ b/terra/msg/tx.py
@@ -2,7 +2,7 @@ from typing import List
 import logging
 
 from terra.account import Account
-from terra.api.transactions import txs
+from terra.api.client import Client
 from terra.msg.fee import Fee
 from terra.msg.auth.stdsignmsg import StdSignMsg
 from terra.msg.auth.stdtx import StdTx
@@ -54,4 +54,4 @@ class Tx(JsonSerializable):
     def broadcast(self) -> dict:
         """Helper function to broadcast the tx."""
         _log.debug(f"Broadcasting tx {self.to_json()}")
-        return txs.post(self.to_json())
+        return Client().broadcast_tx(self.to_json())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,47 +38,47 @@ def response_generic_exception(url, request):
 
 def test_client_get_200():
     with HTTMock(response_200):
-        assert api.client.Client.get("/") == {"test": "test"}
+        assert api.client.Client().get("/") == {"test": "test"}
 
 
 def test_client_get_404():
     with HTTMock(response_404):
         with pytest.raises(exceptions.ApiError) as e:
-            api.client.Client.get("/")
+            api.client.Client().get("/")
             assert e.match("404")
 
 
 def test_client_get_timeout():
     with HTTMock(response_timeout):
         with pytest.raises(exceptions.ApiError) as e:
-            api.client.Client.get("/")
+            api.client.Client().get("/")
             assert e.match("timed out")
 
 
 def test_client_get_not_json():
     with HTTMock(response_not_json):
         with pytest.raises(exceptions.ApiError) as e:
-            api.client.Client.get("/")
+            api.client.Client().get("/")
             assert e.match("json")
 
 
 def test_client_get_too_many_redirects():
     with HTTMock(response_too_many_redirects):
         with pytest.raises(exceptions.ApiError) as e:
-            api.client.Client.get("/")
+            api.client.Client().get("/")
             assert e.match("redirections")
 
 
 def test_client_get_generic_exception():
     with HTTMock(response_generic_exception):
         with pytest.raises(exceptions.ApiError) as e:
-            api.client.Client.get("/")
+            api.client.Client().get("/")
             assert e.match("The endpoint could not be accessed")
 
 
 def test_client_post_200():
     with HTTMock(response_200):
-        assert api.client.Client.post("/", {"some": "json"}) == {
+        assert api.client.Client().post("/", {"some": "json"}) == {
             "test": "test"
         }
 
@@ -86,59 +86,62 @@ def test_client_post_200():
 def test_client_post_404():
     with HTTMock(response_404):
         with pytest.raises(exceptions.ApiError) as e:
-            api.client.Client.post("/", {"some": "json"})
+            api.client.Client().post("/", {"some": "json"})
             assert e.match("404")
 
 
 def test_client_post_timeout():
     with HTTMock(response_timeout):
         with pytest.raises(exceptions.ApiError) as e:
-            api.client.Client.post("/", {"some": "json"})
+            api.client.Client().post("/", {"some": "json"})
             assert e.match("timed out")
 
 
 def test_client_post_not_json():
     with HTTMock(response_not_json):
         with pytest.raises(exceptions.ApiError) as e:
-            api.client.Client.post("/", {"some": "json"})
+            api.client.Client().post("/", {"some": "json"})
             assert e.match("json")
 
 
 def test_client_post_too_many_redirects():
     with HTTMock(response_too_many_redirects):
         with pytest.raises(exceptions.ApiError) as e:
-            api.client.Client.post("/", {"some": "json"})
+            api.client.Client().post("/", {"some": "json"})
             assert e.match("redirections")
 
 
 def test_client_post_generic_exception():
     with HTTMock(response_generic_exception):
         with pytest.raises(exceptions.ApiError) as e:
-            api.client.Client.post("/", {"some": "json"})
+            api.client.Client().post("/", {"some": "json"})
             assert e.match("The endpoint could not be accessed")
 
 
 def test_get_tendermint_node_info():
-    assert list(api.tendermint.node_info.get().keys())[0] == "node_info"
+    assert list(api.client.Client().get_node_info().keys())[0] == "node_info"
 
 
 def test_get_tendermint_blocks_latest():
-    assert list(api.tendermint.blocks.latest.get().keys())[0] == "block_meta"
+    assert list(
+        api.client.Client().get_latest_block().keys())[0] == "block_meta"
 
 
 def test_get_oracle_denoms_actives():
-    assert list(api.oracle.denoms.actives.get().keys())[0] == "height"
+    assert list(api.client.Client().get_active_denoms().keys())[0] == "height"
 
 
 def test_get_auth_accounts_by_address():
     address = "terra1d03dz5n3hj8qfzfjvrza8a9t0hejwnjcdsn5cw"
     assert (
-        list(api.auth.accounts.by_address.get(address).keys())[0] == "height"
+        list(api.client.Client().get_account_by_address(
+            address).keys())[0] == "height"
     )
 
 
 def test_get_bank_balances_by_address():
     address = "terra1d03dz5n3hj8qfzfjvrza8a9t0hejwnjcdsn5cw"
     assert (
-        list(api.bank.balances.by_address.get(address).keys())[0] == "height"
+        list(api.client.Client().get_balance_by_address(
+            address).keys())[0] == "height"
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -123,8 +123,9 @@ def test_get_tendermint_node_info():
 
 
 def test_get_tendermint_blocks_latest():
-    assert list(
-        api.client.Client().get_latest_block().keys())[0] == "block_meta"
+    assert (
+        list(api.client.Client().get_latest_block().keys())[0] == "block_meta"
+    )
 
 
 def test_get_oracle_denoms_actives():
@@ -134,14 +135,14 @@ def test_get_oracle_denoms_actives():
 def test_get_auth_accounts_by_address():
     address = "terra1d03dz5n3hj8qfzfjvrza8a9t0hejwnjcdsn5cw"
     assert (
-        list(api.client.Client().get_account_by_address(
-            address).keys())[0] == "height"
+        list(api.client.Client().get_account_by_address(address).keys())[0]
+        == "height"
     )
 
 
 def test_get_bank_balances_by_address():
     address = "terra1d03dz5n3hj8qfzfjvrza8a9t0hejwnjcdsn5cw"
     assert (
-        list(api.client.Client().get_balance_by_address(
-            address).keys())[0] == "height"
+        list(api.client.Client().get_balance_by_address(address).keys())[0]
+        == "height"
     )


### PR DESCRIPTION
## Problems
1. Exposing member variable such as `URL` is not a good example of data encapsulation. Having users type in URL string before calling an API is not ideal.
2. Users cannot choose mainnet/testnet, which results in errors hard to debug.

## Solution
Create interface where users can choose between mainnet/testnet. Users can keep using `Client` as a static class as how it was, now, users can choose to instantiate the class with an option of mainnet/testnet. If there come more configurations in the future, they can be added in parameter of `__init__()`.